### PR TITLE
fix: Correct fetchWithTimeout import and usage for OllamaClient

### DIFF
--- a/packages/core/src/utils/fetch.ts
+++ b/packages/core/src/utils/fetch.ts
@@ -36,40 +36,28 @@ export function isPrivateIp(url: string): boolean {
   }
 }
 
-// Renaming to fetchWithRetry to match OllamaClient's expectation.
-// Actual retry logic is not implemented here yet.
-export async function fetchWithRetry(
+// Original function name and signature
+export async function fetchWithTimeout(
   url: string,
-  options?: RequestInit, // Added options to be compatible with typical fetch usage
-  timeout = 10000, // Default timeout, can be overridden by options.signal
+  timeout: number, // Original signature had timeout as a direct parameter
+  options?: RequestInit, // Options can be passed but signal for timeout is handled internally
 ): Promise<Response> {
   const controller = new AbortController();
-  let timeoutId: NodeJS.Timeout | undefined;
-
-  // If a signal is provided in options, prefer it. Otherwise, use our timeout.
-  const signal = options?.signal ?? controller.signal;
-  if (!options?.signal) {
-    timeoutId = setTimeout(() => controller.abort(), timeout);
-  }
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
 
   try {
-    // Pass through all options to fetch
-    const response = await fetch(url, { ...options, signal });
+    // Combine passed options with the internal signal for timeout
+    const fetchOptions = { ...options, signal: controller.signal };
+    const response = await fetch(url, fetchOptions);
     return response;
   } catch (error) {
     if (isNodeError(error) && error.code === 'ABORT_ERR') {
-      // Distinguish between external abort and our timeout
-      if (timeoutId && controller.signal.aborted) {
-         throw new FetchError(`Request timed out after ${timeout}ms`, 'ETIMEDOUT');
-      }
-      // If aborted by external signal, rethrow preserving original error if possible
-      // or a generic abort error.
-      throw new FetchError(getErrorMessage(error) || 'Request aborted', 'ABORT_ERR');
+      // This specific error is thrown by fetch when our timeout aborts the request
+      throw new FetchError(`Request timed out after ${timeout}ms`, 'ETIMEDOUT');
     }
+    // For other errors, wrap them in FetchError
     throw new FetchError(getErrorMessage(error));
   } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
+    clearTimeout(timeoutId);
   }
 }


### PR DESCRIPTION
This commit resolves a build error caused by the previous attempt to fix an export issue.

- Reverted the rename of `fetchWithRetry` back to `fetchWithTimeout` in `packages/core/src/utils/fetch.ts` and ensured its signature is `(url: string, timeout: number, options?: RequestInit)`.
- Updated `OllamaClient` in `packages/core/src/services/ollama.ts` to import and use `fetchWithTimeout` with the correct signature, providing appropriate timeout values for its internal requests and for the `generate` method (longer for streams).

This ensures that `web-fetch.ts` continues to function as expected and `OllamaClient` uses the correctly named and implemented timeout utility, resolving the build error.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
