### PR TITLE
Fix: Correctly access generation parameters in OllamaContentGenerator

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -167,21 +167,21 @@ export class OllamaContentGenerator implements ContentGenerator { // Added expor
     // Simplistic mapping for generationConfig - Ollama options are different
     // Simplistic mapping for generationConfig - Ollama options are different
     const options: Record<string, unknown> = {};
-    // THIS IS THE FINAL ATTEMPT: Accessing via request.generationConfig
-    if (request.generationConfig?.temperature !== undefined) {
-      options.temperature = request.generationConfig.temperature;
+    // Access generation parameters via the request.config object
+    if (request.config?.temperature !== undefined) {
+      options.temperature = request.config.temperature;
     }
-    if (request.generationConfig?.topP !== undefined) {
-      options.top_p = request.generationConfig.topP;
+    if (request.config?.topP !== undefined) {
+      options.top_p = request.config.topP;
     }
-    if (request.generationConfig?.topK !== undefined) {
-      options.top_k = request.generationConfig.topK;
+    if (request.config?.topK !== undefined) {
+      options.top_k = request.config.topK;
     }
-    if (request.generationConfig?.maxOutputTokens !== undefined) {
-      options.num_predict = request.generationConfig.maxOutputTokens;
+    if (request.config?.maxOutputTokens !== undefined) {
+      options.num_predict = request.config.maxOutputTokens;
     }
-    if (request.generationConfig?.stopSequences !== undefined) {
-      options.stop = request.generationConfig.stopSequences;
+    if (request.config?.stopSequences !== undefined) {
+      options.stop = request.config.stopSequences;
     }
      // TODO: Handle system instruction if provided in request.contents
      // (e.g. first message with role 'system' or a dedicated field if available)


### PR DESCRIPTION
The `GenerateContentParameters` type from `@google/genai` expects generation settings like temperature, topP, topK, maxOutputTokens, and stopSequences to be passed within a `config` object, not directly on the request or within a nested `generationConfig` object.

This commit updates `OllamaContentGenerator` to access these parameters via `request.config.parameterName` to align with the library's expected structure and resolve TypeScript errors.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
