### PR TITLE
Fix: Resolve vitest dependency conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "prettier": "^3.5.3",
         "react-devtools-core": "^4.28.5",
         "typescript-eslint": "^8.30.1",
-        "vitest": "^3.2.4",
+        "vitest": "^3.1.1",
         "yargs": "^17.7.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prettier": "^3.5.3",
     "react-devtools-core": "^4.28.5",
     "typescript-eslint": "^8.30.1",
-    "vitest": "^3.2.4",
+    "vitest": "^3.1.1",
     "yargs": "^17.7.2"
   },
   "dependencies": {


### PR DESCRIPTION
Downgraded vitest in the root package.json from ^3.2.4 to ^3.1.1. This aligns the vitest version with the requirements of @vitest/coverage-v8@^3.1.1 and the vitest version used in the @google/gemini-cli workspace package, resolving the npm ERESOLVE error during installation.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
