### PR TITLE
Fix: Allow Ollama as a valid auth method

### DIFF
--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -35,5 +35,9 @@ export const validateAuthMethod = (authMethod: string): string | null => {
     return null;
   }
 
+  if (authMethod === AuthType.USE_OLLAMA) {
+    return null; // Ollama runs locally, no specific auth validation needed here.
+  }
+
   return 'Invalid auth method selected.';
 };


### PR DESCRIPTION
Updated the `validateAuthMethod` function in `packages/cli/src/config/auth.ts` to correctly recognize `AuthType.USE_OLLAMA`.

Previously, selecting Ollama in the authentication dialog would result in an "Invalid auth method selected" error because `AuthType.USE_OLLAMA` was not handled in the validation logic. This change adds a condition to return `null` (no error) for Ollama, as it typically runs locally and doesn't require further authentication checks by this function.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
