### PR TITLE
Fix: Resolve 'getFunctionDeclarations' error for Ollama

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -252,6 +252,10 @@ export class Config {
 
     // The GeminiClient might not be appropriate for Ollama.
     // We need to conditionally create and initialize the right client/generator.
+
+    // Initialize ToolRegistry BEFORE client initialization, so it's available.
+    this.toolRegistry = await createToolRegistry(this);
+
     if (authMethod === AuthType.USE_OLLAMA) {
       // For Ollama, contentGeneratorConfig is already prepared by createContentGeneratorConfig
       // And GeminiClient.initialize will call createContentGenerator internally.
@@ -267,7 +271,6 @@ export class Config {
       await gc.initialize(contentConfig); // For Gemini/Vertex, this is fine
       this.contentGeneratorConfig = contentConfig;
     }
-    this.toolRegistry = await createToolRegistry(this);
 
     // Reset the session flag since we're explicitly changing auth and using default model
     this.modelSwitchedDuringSession = false;


### PR DESCRIPTION
Moved the ToolRegistry initialization in `Config.refreshAuth` to occur before the GeminiClient is initialized.

This fixes an error where `toolRegistry.getFunctionDeclarations()` would be called on an undefined `toolRegistry` when using Ollama. The error `Cannot read properties of undefined (reading 'getFunctionDeclarations')` occurred because `GeminiClient.startChat()` was called (via `GeminiClient.initialize()`) before the `Config` instance's `toolRegistry` property was set.

With this change, the ToolRegistry is available when the GeminiChat session is started for Ollama, preventing the TypeError.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
