### PR TITLE
Feat: Allow Ollama model selection via settings and CLI arg

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -68,8 +68,8 @@ async function parseArguments(): Promise<CliArgs> {
     .option('ollamaModel', {
       alias: 'om',
       type: 'string',
-      description: 'Ollama Model',
-      default: process.env.OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL,
+      description: 'Ollama Model (e.g., llama3, gemma:latest). Overrides settings.json and OLLAMA_MODEL env var.',
+      // Default will be handled explicitly in loadCliConfig to allow settings.json to override env var
     })
     .option('prompt', {
       alias: 'p',
@@ -252,7 +252,12 @@ export async function loadCliConfig(
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,
     model: argv.model!,
-    ollamaModel: argv.ollamaModel!,
+    // Determine effectiveOllamaModel with desired precedence:
+    // 1. CLI arg (--ollamaModel)
+    // 2. settings.json (settings.ollamaModel)
+    // 3. Environment variable (OLLAMA_MODEL)
+    // 4. Core default (DEFAULT_OLLAMA_MODEL)
+    ollamaModel: argv.ollamaModel || settings.ollamaModel || process.env.OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL,
     extensionContextFilePaths,
   });
 }


### PR DESCRIPTION
Implemented a clear precedence for determining the Ollama model name:
1. Command-line argument (`--ollamaModel` or `-om`)
2. `ollamaModel` field in `settings.json` (user or project)
3. `OLLAMA_MODEL` environment variable
4. Default (`llama2` from `@google/gemini-cli-core`)

This addresses the issue where the CLI would error if a previously configured or hardcoded Ollama model (e.g., `llama3.1`) was not found. Users can now explicitly configure their desired Ollama model in `settings.json` or override it via CLI/env var.

Changes:
- Modified `parseArguments` in `packages/cli/src/config/config.ts` to remove yargs defaulting for `ollamaModel` flag.
- Updated `loadCliConfig` in `packages/cli/src/config/config.ts` to establish the new precedence logic for `ollamaModel` when creating the core Config.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
