### PR TITLE
Fix: Correct syntax error in Ollama model logging

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -206,6 +206,14 @@ export async function loadCliConfig(
 
   const sandboxConfig = await loadSandboxConfig(settings, argv);
 
+  // Determine effectiveOllamaModel with desired precedence:
+  // 1. CLI arg (--ollamaModel)
+  // 2. settings.json (settings.ollamaModel)
+  // 3. Environment variable (OLLAMA_MODEL)
+  // 4. Core default (DEFAULT_OLLAMA_MODEL)
+  const effectiveOllamaModel = argv.ollamaModel || settings.ollamaModel || process.env.OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL;
+  logToFile(`[loadCliConfig] Effective Ollama Model selected: ${effectiveOllamaModel}`);
+
   return new Config({
     sessionId,
     embeddingModel: DEFAULT_GEMINI_EMBEDDING_MODEL,
@@ -253,13 +261,6 @@ export async function loadCliConfig(
     fileDiscoveryService: fileService,
     bugCommand: settings.bugCommand,
     model: argv.model!,
-    // Determine effectiveOllamaModel with desired precedence:
-    // 1. CLI arg (--ollamaModel)
-    // 2. settings.json (settings.ollamaModel)
-    // 3. Environment variable (OLLAMA_MODEL)
-    // 4. Core default (DEFAULT_OLLAMA_MODEL)
-    const effectiveOllamaModel = argv.ollamaModel || settings.ollamaModel || process.env.OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL;
-    logToFile(`[loadCliConfig] Effective Ollama Model selected: ${effectiveOllamaModel}`);
     ollamaModel: effectiveOllamaModel,
     extensionContextFilePaths,
   });


### PR DESCRIPTION
Moved the declaration of `effectiveOllamaModel` and the associated `logToFile` call in `loadCliConfig` (packages/cli/src/config/config.ts)	o the correct scope, before the `new Config(...)` object instantiation.

This resolves a syntax error that prevented the project from building,\which was introduced in the previous commit while adding logging for Ollama model selection.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
