### PR TITLE
Fix: Resolve build errors from Ollama model selection feature

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -163,26 +163,6 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     }
   }, [settings.merged.selectedAuthType, openAuthDialog, setAuthError]);
 
-  // Effect to trigger Ollama model selection if Ollama auth is chosen and no model is set
-  useEffect(() => {
-    if (
-      settings.merged.selectedAuthType === AuthType.USE_OLLAMA && // AuthType needs to be imported
-      !isAuthDialogOpen && // Only run if AuthDialog is not open
-      !isOllamaModelDialogOpen && // And OllamaModelDialog is not already open
-      !settings.merged.ollamaModel // And no ollamaModel is already set in settings
-    ) {
-      // Potentially add a check here: if (config.getOllamaApiEndpoint()) to ensure it's configured
-      openOllamaModelDialog();
-    }
-  }, [
-    settings.merged.selectedAuthType,
-    settings.merged.ollamaModel,
-    isAuthDialogOpen,
-    isOllamaModelDialogOpen,
-    openOllamaModelDialog,
-    // config, // Add if config.getOllamaApiEndpoint() check is used
-  ]);
-
   const {
     isEditorDialogOpen,
     openEditorDialog,
@@ -205,6 +185,26 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     // For now, just logging or simple re-render might be enough as settings are updated.
     // A more robust solution might involve a way to signal config changes to GeminiClient.
   });
+
+  // Effect to trigger Ollama model selection if Ollama auth is chosen and no model is set
+  useEffect(() => {
+    if (
+      settings.merged.selectedAuthType === AuthType.USE_OLLAMA && // AuthType needs to be imported
+      !isAuthDialogOpen && // Only run if AuthDialog is not open
+      !isOllamaModelDialogOpen && // And OllamaModelDialog is not already open
+      !settings.merged.ollamaModel // And no ollamaModel is already set in settings
+    ) {
+      // Potentially add a check here: if (config.getOllamaApiEndpoint()) to ensure it's configured
+      openOllamaModelDialog();
+    }
+  }, [
+    settings.merged.selectedAuthType,
+    settings.merged.ollamaModel,
+    isAuthDialogOpen,
+    isOllamaModelDialogOpen,
+    openOllamaModelDialog,
+    // config, // Add if config.getOllamaApiEndpoint() check is used
+  ]);
 
   const toggleCorgiMode = useCallback(() => {
     setCorgiMode((prev) => !prev);

--- a/packages/cli/src/ui/components/OllamaModelDialog.tsx
+++ b/packages/cli/src/ui/components/OllamaModelDialog.tsx
@@ -75,8 +75,7 @@ export function OllamaModelDialog({
       <RadioButtonSelect
         items={items}
         initialIndex={initialIndex}
-        onSelect={(item) => onSelect(item.value)}
-        onCancel={onCancel} // Pass cancel if RadioButtonSelect supports it, or rely on useInput above
+        onSelect={onSelect}
         isFocused={true}
       />
       <Box marginTop={1}>

--- a/packages/cli/src/utils/ollamaUtils.ts
+++ b/packages/cli/src/utils/ollamaUtils.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fetch from 'node-fetch'; // Assuming node-fetch is available or can be added
+// Assuming global fetch is available (Node 18+)
+// import fetch from 'node-fetch'; // Removed: node-fetch is not a direct dependency
 
 // Interfaces for Ollama API response
 interface OllamaModelDetails {


### PR DESCRIPTION
Corrected several TypeScript errors that arose during the initial implementation of the interactive Ollama model selection UI:

- In `App.tsx`:
  - Fixed TS2448/TS2454 by reordering the `useOllamaModelSelection` hook call to be before its usage in a `useEffect`.
- In `OllamaModelDialog.tsx`:
  - Fixed TS2551 by adjusting the `onSelect` prop passed to `RadioButtonSelect`, assuming it provides the selected value directly.
  - Fixed TS2322 by removing the unsupported `onCancel` prop from `RadioButtonSelect`.
- In `ollamaUtils.ts`:
  - Addressed TS7016 by removing the explicit `node-fetch` import, relying on the global `fetch` available in Node.js v18+ (as per project's engine requirement).

These changes should allow the project to build successfully.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
