### PR TITLE
Feat: Allow re-selection of Ollama model via /auth flow

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -219,21 +219,19 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   // Effect to trigger Ollama model selection if Ollama auth is chosen and no model is set
   useEffect(() => {
     if (
-      settings.merged.selectedAuthType === AuthType.USE_OLLAMA && // AuthType needs to be imported
+      settings.merged.selectedAuthType === AuthType.USE_OLLAMA &&
       !isAuthDialogOpen && // Only run if AuthDialog is not open
-      !isOllamaModelDialogOpen && // And OllamaModelDialog is not already open
-      !settings.merged.ollamaModel // And no ollamaModel is already set in settings
+      !isOllamaModelDialogOpen // And OllamaModelDialog is not already open
+      // Condition !settings.merged.ollamaModel removed to allow re-selection
     ) {
-      // Potentially add a check here: if (config.getOllamaApiEndpoint()) to ensure it's configured
       openOllamaModelDialog();
     }
   }, [
     settings.merged.selectedAuthType,
-    settings.merged.ollamaModel,
+    // settings.merged.ollamaModel, // Removed from dependency array
     isAuthDialogOpen,
     isOllamaModelDialogOpen,
     openOllamaModelDialog,
-    // config, // Add if config.getOllamaApiEndpoint() check is used
   ]);
 
   const toggleCorgiMode = useCallback(() => {


### PR DESCRIPTION
Modified the `useEffect` in `App.tsx` that triggers the Ollama model selection dialog. The condition `!settings.merged.ollamaModel` was removed.

This change ensures that the `OllamaModelDialog` is presented every time the user confirms or re-confirms Ollama as their authentication method via the `/auth` command flow. This allows users to change their selected Ollama model without needing to manually edit settings files.

The dialog will pre-select the currently configured Ollama model if one is set.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
