### PR TITLE
Fix Ollama dialog loop and ensure it opens only if no model is set

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -220,18 +220,17 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
   useEffect(() => {
     if (
       settings.merged.selectedAuthType === AuthType.USE_OLLAMA &&
-      !isAuthDialogOpen && // Only run if AuthDialog is not open
-      !isOllamaModelDialogOpen // And OllamaModelDialog is not already open
-      // Condition !settings.merged.ollamaModel removed to allow re-selection
+      !settings.merged.ollamaModel &&
+      !isAuthDialogOpen &&
+      !isOllamaModelDialogOpen
     ) {
       openOllamaModelDialog();
     }
   }, [
-    settings.merged.selectedAuthType,
-    // settings.merged.ollamaModel, // Removed from dependency array
+    settings, // Use the whole settings object as a dependency
     isAuthDialogOpen,
     isOllamaModelDialogOpen,
-    openOllamaModelDialog,
+    openOllamaModelDialog
   ]);
 
   const toggleCorgiMode = useCallback(() => {


### PR DESCRIPTION
Adjusted the useEffect hook in App.tsx that manages the Ollama model selection dialog.
- The dialog should now only open if Ollama is the auth type and no model is configured.
- Changed dependency array to use the `settings` object directly to ensure fresh values are used when evaluating conditions, preventing a loop after model selection or cancellation.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
