### PR TITLE
Feat: Siempre mostrar selección de modelos al elegir Ollama

### DIFF
--- a/packages/cli/src/ui/hooks/useOllamaModelSelection.ts
+++ b/packages/cli/src/ui/hooks/useOllamaModelSelection.ts
@@ -86,13 +86,13 @@ export function useOllamaModelSelection(
       logToFile(
         `[useOllamaModelSelection] Model selected in dialog: ${modelName}`,
       );
-      settings.setValue(SettingScope.User, 'ollamaModel', modelName);
+      // settings.setValue is now handled by the callback in App.tsx
       setIsOllamaModelDialogOpen(false);
       if (onModelSelected) {
-        onModelSelected(modelName); // Pass the selected model name
+        onModelSelected(modelName); // Pass the selected model name to App.tsx
       }
     },
-    [settings, onModelSelected],
+    [onModelSelected], // Removed settings from dependencies
   );
 
   const handleDialogClose = useCallback(() => {


### PR DESCRIPTION
Este cambio modifica el flujo de autenticación para Ollama para asegurar que al usuario siempre se le presente el diálogo de selección de modelos cada vez que elija "Ollama" como método de autenticación, ya sea en la configuración inicial o después de usar el comando `/auth`.

Cambios principales:
- `useAuthCommand.ts`:
    - Para `AuthType.USE_OLLAMA`, `performAuthFlow` ahora solo verifica la accesibilidad de Ollama y la existencia de modelos, pero no selecciona ni configura un modelo automáticamente.
    - Se introdujo un callback `onOllamaAuthTypeSelectedAndChecked` que se invoca después de una verificación exitosa de Ollama cuando este es seleccionado.
- `App.tsx`:
    - Utiliza el nuevo callback de `useAuthCommand` para llamar a `openOllamaModelDialog()` incondicionalmente después de que Ollama es seleccionado y verificado.
    - Se eliminó la lógica anterior que abría el diálogo de modelos Ollama solo si no había un modelo previamente configurado.
    - Se mejoró la lógica en los callbacks de `useOllamaModelSelection` para manejar la selección o cancelación del diálogo de modelos, guiando al usuario de vuelta al diálogo de autenticación si es necesario (por ejemplo, si se cancela la selección de modelo y no hay ninguno configurado).
- `useOllamaModelSelection.ts`:
    - Se eliminó una llamada redundante a `settings.setValue` para centralizar esta lógica en `App.tsx`.

Este comportamiento asegura que el usuario tenga control explícito sobre la selección del modelo Ollama en cada interacción con el flujo de autenticación de Ollama.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
