### PR TITLE
Fix: Corregir bucle infinito en la selección de modelos Ollama

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -156,13 +156,12 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     settings,
     setAuthError,
     config,
-    // New callback for when Ollama auth type is selected and pre-check is done
-    () => {
+    useCallback(() => {
       logToFile(
         '[App.tsx] Ollama auth type selected and checked. Opening model dialog.',
       );
-      openOllamaModelDialog(); // Open the Ollama model selection dialog
-    },
+      openOllamaModelDialog();
+    }, [openOllamaModelDialog]), // Dependency: openOllamaModelDialog
   );
 
   useEffect(() => {


### PR DESCRIPTION
Se ha corregido un bucle infinito que ocurría al iniciar la CLI con Ollama como método de autenticación o al seleccionarlo mediante `/auth`.

El problema se debía a que la función callback `onOllamaAuthTypeSelectedAndChecked`, pasada desde `App.tsx` a `useAuthCommand.ts`, se creaba como una nueva instancia en cada renderizado de `App.tsx`. Esto provocaba que el `useEffect` en `useAuthCommand` (que dependía de este callback) se re-ejecutara continuamente, reiniciando el flujo de apertura del diálogo de selección de modelos.

La solución ha sido envolver la definición de este callback en `App.tsx` con `useCallback`, asegurando que su referencia se mantenga estable entre renderizados, a menos que sus propias dependencias cambien. Esto rompe el ciclo de re-ejecución del `useEffect` y estabiliza el flujo de autenticación y selección de modelos para Ollama.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
