### PR TITLE
Fix: Prevenir bucle en selección de Ollama verificando estado de diálogo

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -251,7 +251,8 @@ const App = ({ config, settings, startupWarnings = [] }: AppProps) => {
     settings,
     setAuthError,
     config,
-    handleOllamaAuthSuccessAndOpenModelDialog, // Pass the memoized callback
+    handleOllamaAuthSuccessAndOpenModelDialog,
+    isOllamaModelDialogOpen, // Pass the state here
   );
 
   useEffect(() => {

--- a/packages/cli/src/ui/hooks/useAuthCommand.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.ts
@@ -82,9 +82,10 @@ export const useAuthCommand = (
   settings: LoadedSettings,
   setAuthError: (error: string | null) => void,
   config: Config,
-  // Callback to signal that Ollama auth type was chosen and check was successful,
-  // so App.tsx can open the model selection dialog.
+  // Callback to signal that Ollama auth type was chosen and check was successful
   onOllamaAuthTypeSelectedAndChecked?: () => void,
+  // State from App.tsx to prevent re-triggering model dialog if already open
+  isOllamaModelDialogOpen?: boolean,
 ) => {
   const [isAuthDialogOpen, setIsAuthDialogOpen] = useState(
     settings.merged.selectedAuthType === undefined,
@@ -117,10 +118,12 @@ export const useAuthCommand = (
             setAuthError,
           );
           // If performAuthFlow for Ollama was successful (it didn't throw or call openAuthDialog),
-          // it means Ollama is accessible. Now signal to open model dialog.
+          // it means Ollama is accessible. Now signal to open model dialog,
+          // but only if it's not already open (to break potential loops).
           if (
             settings.merged.selectedAuthType === AuthType.USE_OLLAMA &&
-            !isAuthDialogOpen // Ensure auth dialog is closed
+            !isAuthDialogOpen && // Ensure auth dialog is closed
+            !isOllamaModelDialogOpen // Check if model dialog is already open
           ) {
             onOllamaAuthTypeSelectedAndChecked?.();
           }
@@ -171,7 +174,8 @@ export const useAuthCommand = (
     setAuthError,
     openAuthDialog,
     onOllamaAuthTypeSelectedAndChecked,
-    isAuthenticating, // Added isAuthenticating to dependencies
+    isAuthenticating,
+    isOllamaModelDialogOpen, // Added to dependencies
   ]);
 
   const handleAuthSelect = useCallback(


### PR DESCRIPTION
Este commit introduce una corrección más robusta para el bucle infinito que ocurría durante el flujo de selección de modelos de Ollama.

El problema persistía porque el `useEffect` en `useAuthCommand` se reactivaba al cambiar `isAuthenticating`, y si las otras condiciones se mantenían, volvía a invocar el callback para abrir el diálogo de selección de modelos.

La solución implementada es:
1.  Pasar el estado `isOllamaModelDialogOpen` (que indica si el diálogo de selección de modelos de Ollama ya está abierto) desde `App.tsx` al hook `useAuthCommand`.
2.  En `useAuthCommand`, la condición para llamar al callback `onOllamaAuthTypeSelectedAndChecked` (que abre el diálogo de modelos en `App.tsx`) ahora incluye una verificación de `!isOllamaModelDialogOpen`.

Esto asegura que el callback para abrir el diálogo de modelos solo se llame si dicho diálogo no está ya visible, rompiendo efectivamente el ciclo de re-apertura.

Este commit también incluye las correcciones previas relacionadas con:
- Reordenamiento de hooks y definición de callbacks para resolver errores de inicialización.
- Corrección de sintaxis en `useAuthCommand.ts` (`try...catch...else`).
- Corrección de importación de `SettingScope` en `App.tsx`.
- Correcciones de tipado en tests de `contentGenerator.ollama.test.ts`.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
