### PR TITLE
Refactor: Centralizar control del flujo Ollama en App.tsx

### DIFF
--- a/packages/cli/src/ui/hooks/useAuthCommand.ts
+++ b/packages/cli/src/ui/hooks/useAuthCommand.ts
@@ -21,60 +21,29 @@ async function performAuthFlow(
   openAuthDialog: () => void, // To re-open dialog for model selection if needed
   setAuthError: (error: string | null) => void, // To display errors
 ) {
+  // This function now only handles non-Ollama auth methods.
+  // Ollama setup is initiated by App.tsx.
+  // The `settings` parameter is kept for signature consistency but marked unused.
+  // Guard against being called for Ollama, though the calling useEffect should prevent this.
+  if (authMethod === AuthType.USE_OLLAMA) {
+    console.warn(
+      '[useAuthCommand] performAuthFlow called unexpectedly for Ollama. Flow control for Ollama is in App.tsx.',
+    );
+    return;
+  }
+
   try {
-    if (authMethod === AuthType.USE_OLLAMA) {
-      console.log(
-        '[useAuthCommand] Performing Ollama pre-authentication check...',
-      );
-      const ollamaClient = new OllamaClient(config);
-      try {
-        const availableModels = await ollamaClient.listModels();
-        if (availableModels.models.length === 0) {
-          setAuthError(
-            'No Ollama models found. Please ensure Ollama is running and models are installed.',
-          );
-          openAuthDialog(); // Re-open to allow choosing another method or retrying
-          return; // Stop further processing for Ollama here
-        }
-        // Success: Ollama is running and has models.
-        console.log(
-          '[useAuthCommand] Ollama is accessible and has models. App.tsx will trigger model selection.',
-        );
-        setAuthError(null); // Clear any previous auth errors.
-      } catch (e) {
-        const errorMessage = getErrorMessage(e);
-        console.error(
-          '[useAuthCommand] Ollama accessibility check failed:',
-          errorMessage,
-        );
-        setAuthError(
-          `Ollama check failed: ${errorMessage}. Please ensure Ollama is running and accessible.`,
-        );
-        openAuthDialog(); // Re-open to allow choosing another method or retrying
-        return; // Stop further processing
-      }
-      // No config.refreshAuth here for Ollama; it happens after explicit model selection in App.tsx.
-    } else {
-      // For other auth methods, refreshAuth immediately.
-      await config.refreshAuth(authMethod);
-      console.log(`[useAuthCommand] Authenticated via "${authMethod}".`);
-      setAuthError(null); // Clear any previous auth errors
-    }
+    await config.refreshAuth(authMethod);
+    console.log(`[useAuthCommand] Authenticated via "${authMethod}".`);
+    setAuthError(null);
   } catch (e) {
-    // This catch block handles errors from config.refreshAuth (for non-Ollama methods)
-    // or any other unexpected errors during the flow.
     const errorMessage = getErrorMessage(e);
     console.error(
       `[useAuthCommand] Authentication flow failed for ${authMethod}:`,
       errorMessage,
     );
     setAuthError(`Authentication failed for ${authMethod}: ${errorMessage}.`);
-    // For non-Ollama methods, or if Ollama check itself failed before calling openAuthDialog,
-    // we might want to reopen. However, Ollama's specific catch already calls openAuthDialog.
-    // This ensures openAuthDialog is called if refreshAuth for other methods fails.
-    if (authMethod !== AuthType.USE_OLLAMA) {
-      openAuthDialog();
-    }
+    openAuthDialog(); // Re-open auth dialog on failure for non-Ollama methods
   }
 }
 
@@ -82,10 +51,6 @@ export const useAuthCommand = (
   settings: LoadedSettings,
   setAuthError: (error: string | null) => void,
   config: Config,
-  // Callback to signal that Ollama auth type was chosen and check was successful
-  onOllamaAuthTypeSelectedAndChecked?: () => void,
-  // State from App.tsx to prevent re-triggering model dialog if already open
-  isOllamaModelDialogOpen?: boolean,
 ) => {
   const [isAuthDialogOpen, setIsAuthDialogOpen] = useState(
     settings.merged.selectedAuthType === undefined,
@@ -100,55 +65,36 @@ export const useAuthCommand = (
   useEffect(() => {
     const authFlow = async () => {
       if (isAuthDialogOpen || !settings.merged.selectedAuthType) {
+        setIsAuthenticating(false); // Ensure isAuthenticating is false if we exit early
         return;
       }
 
-      // If Ollama is the selected type, we don't immediately authenticate further here.
-      // The selection itself is the "first step". App.tsx will handle opening the model dialog.
-      // performAuthFlow for Ollama will just do a pre-check.
+      // If Ollama is the selected type, this hook does nothing further for authentication.
+      // App.tsx is responsible for handling the Ollama setup flow.
+      // We just ensure isAuthenticating is false.
       if (settings.merged.selectedAuthType === AuthType.USE_OLLAMA) {
-        if (isAuthenticating) return; // Avoid re-triggering if already in pre-check
-        try {
-          setIsAuthenticating(true);
-          await performAuthFlow(
-            AuthType.USE_OLLAMA,
-            config,
-            settings, // settings is not strictly needed by performAuthFlow for Ollama anymore
-            openAuthDialog,
-            setAuthError,
-          );
-          // If performAuthFlow for Ollama was successful (it didn't throw or call openAuthDialog),
-          // it means Ollama is accessible. Now signal to open model dialog,
-          // but only if it's not already open (to break potential loops).
-          if (
-            settings.merged.selectedAuthType === AuthType.USE_OLLAMA &&
-            !isAuthDialogOpen && // Ensure auth dialog is closed
-            !isOllamaModelDialogOpen // Check if model dialog is already open
-          ) {
-            onOllamaAuthTypeSelectedAndChecked?.();
-          }
-        } catch (e) {
-          // Should be caught by performAuthFlow's catch, but as a safeguard:
-          const errMsg = getErrorMessage(e);
-          setAuthError(`Ollama setup error: ${errMsg}`);
-          openAuthDialog();
-        } finally {
+        console.log(
+          '[useAuthCommand] Ollama selected via settings. App.tsx will handle setup. Ensuring isAuthenticating is false.',
+        );
+        if (isAuthenticating) {
           setIsAuthenticating(false);
         }
-        return; // Stop here for Ollama, App.tsx takes over for model selection
+        return;
       }
 
-      // For other auth types, proceed with the original flow
+      // For other auth types, proceed with authentication.
       try {
         setIsAuthenticating(true);
         await performAuthFlow(
           settings.merged.selectedAuthType as AuthType,
           config,
-          settings,
+          settings, // Pass settings, though performAuthFlow might not use it.
           openAuthDialog,
           setAuthError,
         );
       } catch (e) {
+        // This catch is primarily for unexpected errors if performAuthFlow itself throws
+        // before it can set its own errors (though it should handle its own).
         let errorMessage = `Failed to login.\nMessage: ${getErrorMessage(e)}`;
         if (
           settings.merged.selectedAuthType ===
@@ -169,32 +115,23 @@ export const useAuthCommand = (
     void authFlow();
   }, [
     isAuthDialogOpen,
-    settings,
+    settings.merged.selectedAuthType, // Specific dependency
     config,
     setAuthError,
     openAuthDialog,
-    onOllamaAuthTypeSelectedAndChecked,
-    isAuthenticating,
-    isOllamaModelDialogOpen, // Added to dependencies
+    isAuthenticating, // Keep isAuthenticating to manage its state
   ]);
 
   const handleAuthSelect = useCallback(
     async (authMethod: string | undefined, scope: SettingScope) => {
       if (authMethod) {
-        const previousAuthType = settings.merged.selectedAuthType;
         await clearCachedCredentialFile();
         settings.setValue(scope, 'selectedAuthType', authMethod);
-        // If the method changed TO Ollama, or was already Ollama and re-selected
-        if (authMethod === AuthType.USE_OLLAMA) {
-          // No immediate authFlow call here. The useEffect will pick up the change
-          // in selectedAuthType and trigger the Ollama pre-check.
-          // This also means onOllamaAuthTypeSelectedAndChecked will be called by that useEffect.
-        }
       }
       setIsAuthDialogOpen(false);
-      setAuthError(null); // Clear error when user makes a new selection or closes dialog
+      setAuthError(null);
     },
-    [settings, setAuthError], // Removed onOllamaAuthTypeSelectedAndChecked from here
+    [settings, setAuthError],
   );
 
   const handleAuthHighlight = useCallback((_authMethod: string | undefined) => {

--- a/packages/cli/src/ui/hooks/useOllamaModelSelection.ts
+++ b/packages/cli/src/ui/hooks/useOllamaModelSelection.ts
@@ -86,13 +86,13 @@ export function useOllamaModelSelection(
       logToFile(
         `[useOllamaModelSelection] Model selected in dialog: ${modelName}`,
       );
-      // settings.setValue is now handled by the callback in App.tsx
+      settings.setValue(SettingScope.User, 'ollamaModel', modelName);
       setIsOllamaModelDialogOpen(false);
       if (onModelSelected) {
-        onModelSelected(modelName); // Pass the selected model name to App.tsx
+        onModelSelected(modelName); // Pass the selected model name
       }
     },
-    [onModelSelected], // Removed settings from dependencies
+    [settings, onModelSelected],
   );
 
   const handleDialogClose = useCallback(() => {

--- a/packages/core/src/core/contentGenerator.ollama.test.ts
+++ b/packages/core/src/core/contentGenerator.ollama.test.ts
@@ -262,7 +262,7 @@ describe('OllamaContentGenerator', () => {
           prompt: 'Embed this text',
         }),
       );
-      expect(result.embeddings?.[0]?.values).toEqual([0.1, 0.2, 0.3, 0.4]);
+      expect(result.embeddings[0]?.values).toEqual([0.1, 0.2, 0.3, 0.4]);
     });
     it('should handle string content for embeddings', async () => {
       const geminiRequest: EmbedContentParameters = {
@@ -279,7 +279,7 @@ describe('OllamaContentGenerator', () => {
       expect(mockOllamaClient.embeddings).toHaveBeenCalledWith(
         expect.objectContaining({ prompt: 'Embed this string directly' }),
       );
-      expect(result.embeddings?.[0]?.values).toEqual([0.5, 0.6]);
+      expect(result.embeddings[0]?.values).toEqual([0.5, 0.6]);
     });
 
     it('should throw if prompt text is empty for embeddings', async () => {


### PR DESCRIPTION
Este commit refactoriza significativamente el manejo de la autenticación y selección de modelos para Ollama para solucionar problemas de bucles infinitos y mejorar la claridad del flujo.

Cambios Principales:

1.  **`useAuthCommand.ts` Simplificado:**
    - Se eliminó la lógica activa para `AuthType.USE_OLLAMA` del `useEffect` principal y de `performAuthFlow`.
    - El hook ahora solo establece `selectedAuthType` en `settings` cuando Ollama es elegido en `AuthDialog` y no inicia ningún otro proceso para Ollama.

2.  **`App.tsx` con Control Centralizado para Ollama:**
    - Se introdujo una nueva función `handleOllamaSetup` (envuelta en `useCallback`) que maneja la verificación de la accesibilidad de Ollama y la existencia de modelos. Si tiene éxito, abre el diálogo de selección de modelos (`OllamaModelDialog`); si falla, muestra un error, limpia la configuración de Ollama en `settings` y reabre el `AuthDialog`.
    - Un `useEffect` ahora maneja la transición después de que `AuthDialog` se cierra: si Ollama fue seleccionado, llama a `handleOllamaSetup`.
    - Otro `useEffect` maneja la carga inicial de la aplicación: si Ollama es el método de autenticación configurado, verifica el estado (si un modelo está configurado o no) y llama a `handleOllamaSetup` o intenta inicializar directamente con el modelo guardado (con las verificaciones correspondientes).
    - Los callbacks `onModelSelectedFromDialog` y `onDialogCancelled` pasados a `useOllamaModelSelection` han sido robustecidos para asegurar que el estado en `settings` se actualice correctamente y que el usuario sea guiado de vuelta al `AuthDialog` si la selección de modelo se cancela o falla la configuración.

3.  **Importaciones Necesarias:**
    - Se añadieron las importaciones de `OllamaClient` (de `@google/gemini-cli-core`) y `SettingScope` (de `../config/settings.js`) en `App.tsx`.

Este rediseño tiene como objetivo eliminar las dependencias circulares y los efectos de lado no deseados que causaban bucles, al hacer que `App.tsx` sea el orquestador principal del flujo de Ollama después de la selección inicial del método de autenticación.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviewes your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add links to any gh issues or other external bugs --->
